### PR TITLE
feat(api): ファイルツリー取得エンドポイント実装 #9

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -14,13 +14,14 @@
   "dependencies": {
     "@agentmine/db": "workspace:*",
     "@agentmine/shared": "workspace:*",
+    "@hono/node-server": "^1.13.8",
     "hono": "^4.6.16",
-    "@hono/node-server": "^1.13.8"
+    "ignore": "^7.0.5"
   },
   "devDependencies": {
     "@types/node": "^22.13.1",
-    "tsx": "^4.19.2",
     "tsup": "^8.3.5",
+    "tsx": "^4.19.2",
     "typescript": "^5.7.3"
   }
 }

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -8,6 +8,7 @@ import { memoriesRouter } from "./routes/memories";
 import { runsRouter } from "./routes/runs";
 import { eventsRouter } from "./routes/events";
 import { orchestrateRouter } from "./routes/orchestrate";
+import { filesRouter } from "./routes/files";
 
 export const app = new Hono();
 
@@ -34,6 +35,7 @@ app.route("/api/tasks/:taskId/runs", runsRouter);
 app.route("/api/runs", runsRouter);
 app.route("/api/events", eventsRouter);
 app.route("/api/projects/:projectId/orchestrate", orchestrateRouter);
+app.route("/api/projects/:projectId/files", filesRouter);
 
 // Runners (static for now)
 app.get("/api/runners", (c) =>

--- a/packages/daemon/src/routes/files.ts
+++ b/packages/daemon/src/routes/files.ts
@@ -1,0 +1,142 @@
+import { Hono } from "hono";
+import { db } from "../db";
+import { projects, eq } from "@agentmine/db";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, resolve, relative } from "node:path";
+import ignore from "ignore";
+
+interface FileNode {
+  path: string;
+  type: "file" | "directory";
+  children: FileNode[] | null;
+}
+
+export const filesRouter = new Hono();
+
+async function loadGitignore(repoPath: string): Promise<ReturnType<typeof ignore>> {
+  const ig = ignore();
+  // Always ignore .git directory
+  ig.add(".git");
+  try {
+    const content = await readFile(join(repoPath, ".gitignore"), "utf-8");
+    ig.add(content);
+  } catch {
+    // .gitignore not found — proceed without it
+  }
+  return ig;
+}
+
+async function buildTree(
+  basePath: string,
+  currentPath: string,
+  ig: ReturnType<typeof ignore>,
+  currentDepth: number,
+  maxDepth: number
+): Promise<FileNode[]> {
+  const entries = await readdir(currentPath, { withFileTypes: true });
+  const nodes: FileNode[] = [];
+
+  for (const entry of entries) {
+    const fullPath = join(currentPath, entry.name);
+    const relativePath = relative(basePath, fullPath);
+
+    // Check if ignored by .gitignore rules
+    const isDir = entry.isDirectory();
+    const checkPath = isDir ? relativePath + "/" : relativePath;
+    if (ig.ignores(checkPath)) {
+      continue;
+    }
+
+    if (isDir) {
+      let children: FileNode[] | null = null;
+      if (currentDepth < maxDepth) {
+        children = await buildTree(basePath, fullPath, ig, currentDepth + 1, maxDepth);
+      }
+      nodes.push({ path: relativePath, type: "directory", children });
+    } else {
+      nodes.push({ path: relativePath, type: "file", children: null });
+    }
+  }
+
+  // Sort: directories first, then alphabetical
+  nodes.sort((a, b) => {
+    if (a.type !== b.type) return a.type === "directory" ? -1 : 1;
+    return a.path.localeCompare(b.path);
+  });
+
+  return nodes;
+}
+
+// GET /api/projects/:projectId/files
+filesRouter.get("/", async (c) => {
+  const projectId = Number(c.req.param("projectId"));
+  const pathParam = c.req.query("path") ?? ".";
+  const depthParam = Number(c.req.query("depth") ?? "2");
+
+  const depth = Number.isNaN(depthParam) || depthParam < 1 ? 2 : depthParam;
+
+  // Get project to find repo_path
+  const project = await db
+    .select()
+    .from(projects)
+    .where(eq(projects.id, projectId));
+
+  if (project.length === 0) {
+    return c.json(
+      {
+        error: {
+          code: "NOT_FOUND",
+          message: "Project not found",
+        },
+      },
+      404
+    );
+  }
+
+  const repoPath = project[0]!.repoPath;
+
+  // Resolve target path and validate it's within repo
+  const targetPath = resolve(repoPath, pathParam);
+  if (!targetPath.startsWith(resolve(repoPath))) {
+    return c.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Path must be within the project repository",
+        },
+      },
+      400
+    );
+  }
+
+  // Verify target path exists and is a directory
+  try {
+    const s = await stat(targetPath);
+    if (!s.isDirectory()) {
+      return c.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Path is not a directory",
+          },
+        },
+        400
+      );
+    }
+  } catch {
+    return c.json(
+      {
+        error: {
+          code: "NOT_FOUND",
+          message: "Path not found",
+        },
+      },
+      404
+    );
+  }
+
+  const ig = await loadGitignore(repoPath);
+  const tree = await buildTree(repoPath, targetPath, ig, 1, depth);
+
+  return c.json({ data: tree });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       hono:
         specifier: ^4.6.16
         version: 4.11.7
+      ignore:
+        specifier: ^7.0.5
+        version: 7.0.5
     devDependencies:
       '@types/node':
         specifier: ^22.13.1
@@ -1549,6 +1552,10 @@ packages:
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -3451,6 +3458,8 @@ snapshots:
 
   ieee754@1.2.1:
     optional: true
+
+  ignore@7.0.5: {}
 
   inherits@2.0.4:
     optional: true


### PR DESCRIPTION
## Summary
- `GET /api/projects/:projectId/files` エンドポイントを追加
- クエリパラメータ: `path`（デフォルト `.`）、`depth`（デフォルト `2`）
- `ignore` パッケージで `.gitignore` 対象ファイルを除外
- パストラバーサル防止のバリデーション

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)