### PR TITLE
feat: repoPath バリデーション追加と UI 改善

### DIFF
--- a/packages/daemon/src/routes/projects.ts
+++ b/packages/daemon/src/routes/projects.ts
@@ -1,6 +1,22 @@
 import { Hono } from "hono";
+import { execSync } from "child_process";
+import { existsSync } from "fs";
+import { resolve } from "path";
 import { db } from "../db";
 import { projects, eq } from "@agentmine/db";
+
+function validateRepoPath(repoPath: string): { ok: true } | { ok: false; message: string } {
+  const resolved = resolve(repoPath);
+  if (!existsSync(resolved)) {
+    return { ok: false, message: `Path does not exist: ${resolved}` };
+  }
+  try {
+    execSync("git rev-parse --is-inside-work-tree", { cwd: resolved, stdio: "pipe" });
+  } catch {
+    return { ok: false, message: `Not a git repository: ${resolved}` };
+  }
+  return { ok: true };
+}
 
 export const projectsRouter = new Hono();
 
@@ -24,6 +40,14 @@ projectsRouter.post("/", async (c) => {
           message: "name, repoPath, baseBranch are required",
         },
       },
+      400
+    );
+  }
+
+  const pathCheck = validateRepoPath(repoPath);
+  if (!pathCheck.ok) {
+    return c.json(
+      { error: { code: "INVALID_REPO_PATH", message: pathCheck.message } },
       400
     );
   }
@@ -73,7 +97,16 @@ projectsRouter.patch("/:id", async (c) => {
   };
 
   if (body.name !== undefined) updateData.name = body.name;
-  if (body.repoPath !== undefined) updateData.repoPath = body.repoPath;
+  if (body.repoPath !== undefined) {
+    const pathCheck = validateRepoPath(body.repoPath);
+    if (!pathCheck.ok) {
+      return c.json(
+        { error: { code: "INVALID_REPO_PATH", message: pathCheck.message } },
+        400
+      );
+    }
+    updateData.repoPath = body.repoPath;
+  }
   if (body.baseBranch !== undefined) updateData.baseBranch = body.baseBranch;
 
   const result = await db

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -104,7 +104,7 @@ export default function ProjectSwitcher() {
                     value={formData.repoPath}
                     onChange={(e) => setFormData({ ...formData, repoPath: e.target.value })}
                     className="w-full px-3 py-2 bg-zinc-800 border border-zinc-600 rounded text-zinc-100 focus:border-blue-500 focus:outline-none"
-                    placeholder="/home/user/projects/my-repo"
+                    placeholder="例: /home/user/my-repo, C:\Users\user\my-repo"
                     required
                   />
                 </div>


### PR DESCRIPTION
## Summary
- `projects.ts` の POST/PATCH に repoPath バリデーション追加（存在確認 + git リポジトリ確認）
- UI プレースホルダーを Linux/Windows 両方のパス例に変更

## Test plan
- [ ] 存在しないパスでプロジェクト作成 → 400 エラーを確認
- [ ] git リポジトリでないパスで作成 → 400 エラーを確認
- [ ] 正しいパスで作成 → 成功を確認
- [ ] PATCH でも同様のバリデーションが動作することを確認

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)