### PR TITLE
fix: ランナー起動失敗時のDB放置とログパース脆弱性を修正

### DIFF
--- a/packages/daemon/src/routes/orchestrate.ts
+++ b/packages/daemon/src/routes/orchestrate.ts
@@ -156,7 +156,7 @@ Human（ユーザー）からの指令を分析し、独立したサブタスク
 ## 指令
 ${command}`;
 
-  // RunnerAdapter呼び出し（非同期で実行）
+  // RunnerAdapter呼び出し（非同期で実行、失敗時はDB更新）
   runnerManager
     .start(
       coordinatorRunId,
@@ -166,11 +166,15 @@ ${command}`;
       profile[0]!.model || undefined,
       profile[0]!.config || undefined
     )
-    .catch((err) => {
+    .catch(async (err) => {
       console.error(
         `Failed to start coordinator run ${coordinatorRunId}:`,
         err
       );
+      await db
+        .update(runs)
+        .set({ status: "failed", finishedAt: new Date().toISOString() })
+        .where(eq(runs.id, coordinatorRunId));
     });
 
   return c.json(

--- a/packages/daemon/src/routes/runs.ts
+++ b/packages/daemon/src/routes/runs.ts
@@ -131,7 +131,7 @@ ${basePrompt}`
 
   const newRun = result[0]!;
 
-  // RunnerAdapter呼び出し（非同期で実行）
+  // RunnerAdapter呼び出し（非同期で実行、失敗時はDB更新）
   runnerManager
     .start(
       newRun.id,
@@ -141,8 +141,12 @@ ${basePrompt}`
       params.profile.model || undefined,
       params.profile.config || undefined
     )
-    .catch((err) => {
+    .catch(async (err) => {
       console.error(`Failed to start runner for run ${newRun.id}:`, err);
+      await db
+        .update(runs)
+        .set({ status: "failed", finishedAt: new Date().toISOString() })
+        .where(eq(runs.id, newRun.id));
     });
 
   return { ok: true, run: newRun };
@@ -329,7 +333,9 @@ runsRouter.get("/:id/logs", async (c) => {
     const lines = content
       .split("\n")
       .filter((l) => l.trim())
-      .map((l) => JSON.parse(l));
+      .flatMap((l) => {
+        try { return [JSON.parse(l)]; } catch { return []; }
+      });
     return c.json({ data: lines });
   } catch {
     return c.json({ data: [] });

--- a/packages/daemon/src/runner/manager.ts
+++ b/packages/daemon/src/runner/manager.ts
@@ -110,10 +110,9 @@ class RunnerManager {
 
     // logRefをDBに記録
     const logRef = join(LOG_DIR, `${runId}.jsonl`);
-    db.update(runs)
+    await db.update(runs)
       .set({ logRef })
-      .where(eq(runs.id, runId))
-      .catch((err) => console.error(`[run:${runId}] Failed to set logRef:`, err));
+      .where(eq(runs.id, runId));
 
     eventEmitter.emitRunEvent("run.started", { runId });
 


### PR DESCRIPTION
## Summary
- `runnerManager.start()` が失敗した場合、run ステータスを "failed" に更新（"running" のまま放置されるバグを修正）
- `manager.ts` の logRef DB 更新を `await` して確実に書き込み
- ログ読み取りの `JSON.parse` を行単位で安全にパース（1行の破損で全体が失敗するバグを修正）

## Test plan
- [ ] ランナー起動失敗時に run ステータスが "failed" に更新されることを確認
- [ ] ログファイルに不正な行があっても他の行が正しく読み取れることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)