### PR TITLE
feat(backend): スコープ違反検出（write_scope外変更の検出）

### DIFF
--- a/docs/03-details/api-profiles-settings.md
+++ b/docs/03-details/api-profiles-settings.md
@@ -115,6 +115,7 @@ dod.requiredChecksの各要素：
 | クエリパラメータ | 説明                    |
 | ---------------- | ----------------------- |
 | status           | runのstatusでフィルタ   |
+| reason_codes     | reason codes（needs_review理由、dod_failed等）でフィルタ |
 | task_id          | taskでフィルタ          |
 | agent_profile_id | agent_profileでフィルタ |
 | since            | 指定時刻以降のrunのみ   |

--- a/docs/03-details/api-profiles-settings.md
+++ b/docs/03-details/api-profiles-settings.md
@@ -112,13 +112,13 @@ dod.requiredChecksの各要素：
 
 モニター画面用の集約データを取得する。
 
-| クエリパラメータ | 説明                    |
-| ---------------- | ----------------------- |
-| status           | runのstatusでフィルタ   |
+| クエリパラメータ | 説明                                                     |
+| ---------------- | -------------------------------------------------------- |
+| status           | runのstatusでフィルタ                                    |
 | reason_codes     | reason codes（needs_review理由、dod_failed等）でフィルタ |
-| task_id          | taskでフィルタ          |
-| agent_profile_id | agent_profileでフィルタ |
-| since            | 指定時刻以降のrunのみ   |
+| task_id          | taskでフィルタ                                           |
+| agent_profile_id | agent_profileでフィルタ                                  |
+| since            | 指定時刻以降のrunのみ                                    |
 
 | レスポンス | 説明                                                                    |
 | ---------- | ----------------------------------------------------------------------- |

--- a/packages/daemon/src/runner/manager.ts
+++ b/packages/daemon/src/runner/manager.ts
@@ -4,6 +4,7 @@ import type { RunnerAdapter, RunHandle, RunOutput } from "./types";
 import { db } from "../db";
 import { runs, eq } from "@agentmine/db";
 import { eventEmitter } from "../events/emitter";
+import { detectScopeViolations } from "./scope-check";
 import { appendFileSync, mkdirSync, existsSync } from "fs";
 import { join } from "path";
 
@@ -75,6 +76,13 @@ class RunnerManager {
       .where(eq(runs.id, runId));
 
     this.handles.delete(runId);
+
+    // スコープ違反検出（完了時のみ）
+    if (status === "completed") {
+      detectScopeViolations(runId).catch((err) => {
+        console.error(`[run:${runId}] Scope violation check failed:`, err);
+      });
+    }
 
     eventEmitter.emitRunEvent("run.finished", { runId, status, exitCode });
   }

--- a/packages/daemon/src/runner/scope-check.ts
+++ b/packages/daemon/src/runner/scope-check.ts
@@ -1,0 +1,56 @@
+import { execSync } from "child_process";
+import ignore from "ignore";
+import { db } from "../db";
+import { runs, scopeViolations, eq } from "@agentmine/db";
+
+/**
+ * Run完了時にwrite_scope外の変更ファイルを検出し、scope_violationsに記録する
+ */
+export async function detectScopeViolations(runId: number): Promise<void> {
+  const runResult = await db.select().from(runs).where(eq(runs.id, runId));
+  const run = runResult[0];
+  if (!run) return;
+
+  const { worktreePath, scopeSnapshot, headSha } = run;
+  if (!worktreePath || !scopeSnapshot || scopeSnapshot.length === 0) return;
+
+  // 変更ファイル一覧を取得
+  let changedFiles: string[];
+  try {
+    const diffBase = headSha ?? "HEAD~1";
+    const output = execSync(`git diff --name-only ${diffBase}`, {
+      cwd: worktreePath,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    changedFiles = output
+      .split("\n")
+      .map((f) => f.trim())
+      .filter((f) => f.length > 0);
+  } catch {
+    // diff取得に失敗した場合はスキップ
+    console.error(`[run:${runId}] Failed to get git diff for scope check`);
+    return;
+  }
+
+  if (changedFiles.length === 0) return;
+
+  // write_scopeのglobでマッチャーを構築
+  const ig = ignore().add(scopeSnapshot);
+
+  // write_scopeにマッチしないファイルが違反
+  const violations = changedFiles.filter((file) => !ig.ignores(file));
+
+  if (violations.length === 0) return;
+
+  // scope_violationsテーブルに記録
+  await db.insert(scopeViolations).values(
+    violations.map((path) => ({
+      runId,
+      path,
+      reason: "outside_write_scope",
+    }))
+  );
+
+  console.log(`[run:${runId}] Detected ${violations.length} scope violation(s)`);
+}


### PR DESCRIPTION
## Summary
- Run完了時に `git diff --name-only` で変更ファイルを検出
- `ignore` パッケージで write_scope (glob) とのマッチング
- マッチしない変更を `scope_violations` テーブルに記録

Closes #14

## Test plan
- [ ] write_scope外のファイル変更時にscope_violationsレコードが作成される
- [ ] write_scope内のファイルのみ変更時は違反なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)