### PR TITLE
ターミナル出力パーサー改善 + Monitor画面ライブペイン削除

### DIFF
--- a/packages/daemon/src/routes/orchestrate.ts
+++ b/packages/daemon/src/routes/orchestrate.ts
@@ -146,7 +146,8 @@ ${command}`;
       worktreePath,
       prompt,
       profile[0]!.model || undefined,
-      profile[0]!.config || undefined
+      profile[0]!.config || undefined,
+      projectId
     )
     .catch((err) => {
       console.error(`Failed to start coordinator run ${coordinatorRunId}:`, err);

--- a/packages/daemon/src/routes/runs.ts
+++ b/packages/daemon/src/routes/runs.ts
@@ -137,7 +137,8 @@ ${basePrompt}`
       worktreePath,
       prompt,
       params.profile.model || undefined,
-      params.profile.config || undefined
+      params.profile.config || undefined,
+      params.projectId
     )
     .catch((err) => {
       console.error(`Failed to start runner for run ${newRun.id}:`, err);

--- a/packages/daemon/src/runner/manager.ts
+++ b/packages/daemon/src/runner/manager.ts
@@ -14,6 +14,7 @@ const LOG_DIR = "/tmp/agentmine/logs";
 class RunnerManager {
   private adapters: Map<string, RunnerAdapter> = new Map();
   private handles: Map<number, RunHandle> = new Map();
+  private runProjectMap: Map<number, number> = new Map();
 
   constructor() {
     const claude = new ClaudeAdapter();
@@ -52,8 +53,10 @@ class RunnerManager {
     }
 
     // イベント発行（emitRunEventでSSEワイルドカードリスナーにも届く）
+    const projectId = this.runProjectMap.get(runId);
     eventEmitter.emitRunEvent("run.output", {
       runId,
+      projectId,
       ...output,
     });
 
@@ -88,7 +91,9 @@ class RunnerManager {
       });
     }
 
-    eventEmitter.emitRunEvent("run.finished", { runId, status, exitCode });
+    const projectId = this.runProjectMap.get(runId);
+    eventEmitter.emitRunEvent("run.finished", { runId, projectId, status, exitCode });
+    this.runProjectMap.delete(runId);
   }
 
   getAdapter(name: string): RunnerAdapter | undefined {
@@ -105,10 +110,13 @@ class RunnerManager {
     worktreePath: string,
     prompt: string,
     model?: string,
-    config?: Record<string, unknown>
+    config?: Record<string, unknown>,
+    projectId?: number
   ): Promise<RunHandle | null> {
     const adapter = this.adapters.get(runner);
     if (!adapter) return null;
+
+    if (projectId) this.runProjectMap.set(runId, projectId);
 
     const handle = await adapter.start({
       runId,
@@ -127,7 +135,7 @@ class RunnerManager {
       .where(eq(runs.id, runId))
       .catch((err) => console.error(`[run:${runId}] Failed to set logRef:`, err));
 
-    eventEmitter.emitRunEvent("run.started", { runId });
+    eventEmitter.emitRunEvent("run.started", { runId, projectId });
 
     return handle;
   }
@@ -154,7 +162,9 @@ class RunnerManager {
 
     this.handles.delete(runId);
 
-    eventEmitter.emitRunEvent("run.cancelled", { runId });
+    const projectId = this.runProjectMap.get(runId);
+    eventEmitter.emitRunEvent("run.cancelled", { runId, projectId });
+    this.runProjectMap.delete(runId);
   }
 
   private findRunnerForHandle(runId: number): string | undefined {

--- a/packages/web/src/app/p/[projectId]/monitor/page.tsx
+++ b/packages/web/src/app/p/[projectId]/monitor/page.tsx
@@ -4,9 +4,9 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
 import { tasksApi, agentProfilesApi, runsApi, type Task, type Run } from "@/lib/api";
 import { useState, useMemo, useCallback, useRef, useEffect } from "react";
-import { useAppStore, type OutputLine } from "@/lib/store";
+import { useAppStore } from "@/lib/store";
 import { StatusBadge } from "@/components/StatusBadge";
-import { TerminalOutput, parseStreamJsonLine } from "@/components/TerminalOutput";
+import { TerminalOutput } from "@/components/TerminalOutput";
 
 type ExtendedRun = Run & { taskTitle: string; taskId: number; agentProfileName?: string };
 
@@ -32,180 +32,6 @@ const formatTime = (dateStr: string) => {
   const d = new Date(dateStr);
   return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
 };
-
-// ライブターミナルグリッド: 実行中のRunをShogun風に並べて表示
-function LiveTerminalGrid({
-  runs,
-  runOutputs,
-}: {
-  runs: ExtendedRun[];
-  runOutputs: Map<number, OutputLine[]>;
-}) {
-  // 実行中 + 最近出力があったRunを表示
-  const liveRuns = useMemo(() => {
-    const running = runs.filter((r) => r.status === "running");
-    // 実行中がなければ、出力バッファがあるRunのうち最新のものを表示
-    if (running.length === 0) {
-      const withOutput = runs
-        .filter((r) => runOutputs.has(r.id) && (runOutputs.get(r.id)?.length ?? 0) > 0)
-        .sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime())
-        .slice(0, 4);
-      return withOutput;
-    }
-    return running;
-  }, [runs, runOutputs]);
-
-  if (liveRuns.length === 0) return null;
-
-  const gridCols = liveRuns.length === 1 ? "grid-cols-1" : "grid-cols-2";
-
-  return (
-    <div className="mx-3 mt-2">
-      <div className="flex items-center gap-2 mb-1.5">
-        <span className="text-[11px] font-semibold" style={{ color: "#d4d4d4" }}>
-          ライブ実行
-        </span>
-        {liveRuns.some((r) => r.status === "running") && (
-          <span className="flex items-center gap-1.5 text-[11px]" style={{ color: "#cca700" }}>
-            <span className="w-1.5 h-1.5 rounded-full bg-yellow-500 animate-pulse" />
-            {liveRuns.filter((r) => r.status === "running").length} 件実行中
-          </span>
-        )}
-      </div>
-      <div className={`grid ${gridCols} gap-2`} style={{ maxHeight: 320 }}>
-        {liveRuns.map((run) => (
-          <LiveTerminalPane key={run.id} run={run} lines={runOutputs.get(run.id) ?? []} />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function LiveTerminalPane({ run, lines }: { run: ExtendedRun; lines: OutputLine[] }) {
-  const paneRef = useRef<HTMLDivElement>(null);
-  const isRunning = run.status === "running";
-
-  useEffect(() => {
-    if (paneRef.current) {
-      paneRef.current.scrollTop = paneRef.current.scrollHeight;
-    }
-  }, [lines.length]);
-
-  const statusColor = isRunning
-    ? "#cca700"
-    : run.status === "completed"
-      ? "#89d185"
-      : run.status === "failed"
-        ? "#f14c4c"
-        : "#a0a0a0";
-
-  return (
-    <div
-      className="rounded-lg border overflow-hidden flex flex-col"
-      style={{ background: "#0d1117", borderColor: "#30363d", maxHeight: 320 }}
-    >
-      {/* ペインヘッダー */}
-      <div
-        className="flex items-center gap-2 px-2.5 py-1.5 border-b"
-        style={{ background: "#161b22", borderColor: "#30363d" }}
-      >
-        <span
-          className="w-2 h-2 rounded-full"
-          style={{
-            background: statusColor,
-            boxShadow: isRunning ? `0 0 6px ${statusColor}` : "none",
-          }}
-        />
-        <span className="text-[11px] font-semibold" style={{ color: "#c9d1d9" }}>
-          実行 #{run.id}
-        </span>
-        <span
-          className="text-[10px] px-1.5 py-0.5 rounded border"
-          style={{ color: "#8b949e", background: "#21262d", borderColor: "#30363d" }}
-        >
-          {run.taskTitle}
-        </span>
-        <span className="text-[10px] font-mono ml-auto" style={{ color: "#8b949e" }}>
-          {run.agentProfileName}
-        </span>
-        <span className="text-[10px] font-mono" style={{ color: "#8b949e" }}>
-          {formatDuration(run.startedAt, run.finishedAt)}
-        </span>
-      </div>
-      {/* ターミナル本体 */}
-      <div
-        ref={paneRef}
-        className="flex-1 overflow-auto px-2 py-1.5 font-mono text-[10px] leading-[1.5]"
-        style={{ minHeight: 80 }}
-      >
-        {lines.length === 0 ? (
-          <div className="flex items-center justify-center h-full" style={{ color: "#484f58" }}>
-            {isRunning ? (
-              <span className="flex items-center gap-1.5">
-                <span className="w-1.5 h-1.5 rounded-full bg-yellow-500 animate-pulse" />
-                出力を待機中...
-              </span>
-            ) : (
-              "出力なし"
-            )}
-          </div>
-        ) : (
-          lines.slice(-100).map((line, i) => {
-            if (line.type === "system") {
-              return (
-                <div key={i} style={{ color: "#58a6ff" }}>
-                  --- {line.data}
-                </div>
-              );
-            }
-            if (line.type === "stderr") {
-              return (
-                <div key={i} style={{ color: "#f85149" }}>
-                  {line.data}
-                </div>
-              );
-            }
-            if (line.type === "exit") {
-              const c = line.exitCode === 0 ? "#7ee787" : "#f85149";
-              return (
-                <div key={i} style={{ color: c }}>
-                  EXIT code={line.exitCode}
-                </div>
-              );
-            }
-            // stdout: stream-jsonパース
-            const raw = line.data ?? "";
-            const jsonLines = raw.split("\n").filter((l) => l.trim());
-            return (
-              <div key={i}>
-                {jsonLines.map((jl, j) => {
-                  const parsed = parseStreamJsonLine(jl);
-                  if (parsed) {
-                    return (
-                      <div key={j} className="flex gap-1">
-                        <span className="shrink-0" style={{ color: parsed.color, opacity: 0.6 }}>
-                          {parsed.label}
-                        </span>
-                        <span style={{ color: parsed.color, wordBreak: "break-all" }}>
-                          {parsed.text.slice(0, 300)}
-                        </span>
-                      </div>
-                    );
-                  }
-                  return jl.trim() ? (
-                    <div key={j} style={{ color: "#c9d1d9" }}>
-                      {jl.slice(0, 300)}
-                    </div>
-                  ) : null;
-                })}
-              </div>
-            );
-          })
-        )}
-      </div>
-    </div>
-  );
-}
 
 export default function MonitorPage() {
   const params = useParams();
@@ -739,9 +565,6 @@ export default function MonitorPage() {
           </div>
         </div>
       )}
-
-      {/* Live Terminal Grid (Shogun-style multi-pane) */}
-      <LiveTerminalGrid runs={allRuns ?? []} runOutputs={runOutputs} />
 
       {/* Split: Tree + Table */}
       <div

--- a/packages/web/src/components/TerminalOutput.tsx
+++ b/packages/web/src/components/TerminalOutput.tsx
@@ -3,17 +3,64 @@
 import { useRef, useEffect } from "react";
 import type { OutputLine } from "@/lib/store";
 
-export function parseStreamJsonLine(
-  raw: string
-): { label: string; text: string; color: string } | null {
+export type ParsedLine = { label: string; text: string; color: string };
+export type ParseResult = ParsedLine | "skip" | null;
+
+function summarizeInput(input: Record<string, unknown>): string {
+  if (!input) return "";
+  if (input.command) return String(input.command).slice(0, 80);
+  if (input.file_path) return String(input.file_path);
+  if (input.pattern) return String(input.pattern);
+  if (input.query) return String(input.query).slice(0, 80);
+  if (input.prompt) return String(input.prompt).slice(0, 60);
+  const keys = Object.keys(input);
+  return keys.length > 0 ? keys.join(", ") : "";
+}
+
+const SKIP_TYPES = new Set([
+  "message_start", "message_delta", "message_stop",
+  "content_block_stop", "rate_limit_event",
+]);
+
+export function parseStreamJsonLine(raw: string): ParseResult {
   try {
     const obj = JSON.parse(raw);
+
+    // ノイズイベントをスキップ
+    if (SKIP_TYPES.has(obj.type)) return "skip";
+    // content_block_start の text 型もスキップ（本文は assistant イベントで来る）
+    if (obj.type === "content_block_start" && obj.content_block?.type === "text") return "skip";
+
     if (obj.type === "assistant" && obj.message?.content) {
       const texts = obj.message.content
         .filter((c: { type: string }) => c.type === "text")
         .map((c: { text: string }) => c.text);
       if (texts.length > 0) return { label: "assistant", text: texts.join(""), color: "#c9d1d9" };
+
+      // tool_useのみの場合
+      const toolUses = obj.message.content.filter((c: { type: string }) => c.type === "tool_use");
+      if (toolUses.length > 0) {
+        const t = toolUses[0];
+        return { label: "tool", text: `${t.name}(${summarizeInput(t.input)})`, color: "#d2a8ff" };
+      }
+      return "skip"; // contentが空
     }
+
+    if (obj.type === "user" && obj.message?.content) {
+      const results = obj.message.content.filter(
+        (c: { type: string }) => c.type === "tool_result"
+      );
+      if (results.length > 0) {
+        const r = results[0];
+        const text = typeof r.content === "string" ? r.content : JSON.stringify(r.content);
+        if (r.is_error) {
+          return { label: "error", text: text.slice(0, 200), color: "#f85149" };
+        }
+        return { label: "result", text: text.slice(0, 200), color: "#7ee787" };
+      }
+      return "skip";
+    }
+
     if (obj.type === "content_block_delta" && obj.delta?.text) {
       return { label: "text", text: obj.delta.text, color: "#c9d1d9" };
     }
@@ -29,14 +76,16 @@ export function parseStreamJsonLine(
         typeof obj.result === "string"
           ? obj.result.slice(0, 200)
           : JSON.stringify(obj).slice(0, 200);
-      return { label: "result", text: preview, color: "#7ee787" };
+      return { label: "done", text: preview, color: "#7ee787" };
     }
-    if (obj.type === "system" || obj.type === "init") {
-      return {
-        label: "system",
-        text: JSON.stringify(obj).slice(0, 150),
-        color: "#58a6ff",
-      };
+    if (obj.type === "result") {
+      return { label: "error", text: obj.error ?? obj.subtype ?? "execution error", color: "#f85149" };
+    }
+    if (obj.type === "system" && obj.subtype === "init") {
+      return { label: "init", text: `session started (${obj.model ?? "unknown"})`, color: "#58a6ff" };
+    }
+    if (obj.type === "system") {
+      return { label: "system", text: obj.subtype ?? "system event", color: "#58a6ff" };
     }
     if (obj.type) {
       return {
@@ -147,6 +196,7 @@ export function TerminalOutput({
           const elements: React.ReactNode[] = [];
           for (const jsonLine of jsonLines) {
             const parsed = parseStreamJsonLine(jsonLine);
+            if (parsed === "skip") continue;
             if (parsed) {
               elements.push(
                 <div key={`${i}-${elements.length}`} className="py-0.5 flex gap-1.5">


### PR DESCRIPTION
## Summary
- stream-jsonパーサー(`parseStreamJsonLine`)を改善し、ノイズイベントの非表示・tool_use/tool_result/エラーの適切な表示を実装
- SSEイベントにprojectIdを付与してクライアント側フィルタを可能に
- Monitor画面のLiveTerminalGrid/Paneを削除（Live画面と機能重複のため）

## Test plan
- [ ] Live画面でオーケストレーター起動し、ノイズ行(message_start, rate_limit_event等)が非表示であること
- [ ] assistantテキストが白で表示されること
- [ ] ツール呼び出しが紫の`tool`ラベルで表示されること
- [ ] ツール結果が緑の`result`ラベルで表示されること
- [ ] initが`session started (model名)`形式で表示されること
- [ ] エラー時は赤の`error`ラベルで表示されること
- [ ] Monitor画面にライブペインが表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)